### PR TITLE
Improve cleanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer "coveo"
 # Install requierements
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget \
-        cron python puppet python-setuptools python-dev build-essential \
-        libsasl2-dev libldap2-dev libssl-dev && \
+    cron python puppet python-setuptools python-dev build-essential \
+    libsasl2-dev libldap2-dev libssl-dev && \
     easy_install pip
 
 RUN service puppet stop && systemctl disable puppet
@@ -15,10 +15,10 @@ RUN service puppet stop && systemctl disable puppet
 RUN mkdir /install && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     touch /var/log/cron.log
-
-RUN pip install baker python-foreman requests python-ldap boto3
-
 COPY files/install /install
+
+RUN pip install -r /install/requirements.txt
+
 RUN chmod +x /install/entrypoint.sh
 
 CMD ["/install/entrypoint.sh"]

--- a/files/install/entrypoint.sh
+++ b/files/install/entrypoint.sh
@@ -9,5 +9,6 @@ chmod +x /root/envs.sh
 
 # Add cron for clean
 echo "0 * * * * root . /root/envs.sh; /usr/bin/python -W ignore /install/host-cleaner.py clean_old_host > /proc/1/fd/1" >> /etc/cron.d/foreman-cleaner
-
+# Add cron to clean all old certificates 
+echo "30 11 * * * root . /root/envs.sh; /usr/bin/python -W ignore /install/host-cleaner.py clean_old_certificates > /proc/1/fd/1" >> /etc/cron.d/foreman-cleaner
 service cron restart && tail -f /var/log/cron.log

--- a/files/install/host-cleaner.py
+++ b/files/install/host-cleaner.py
@@ -60,7 +60,7 @@ def foreman_wrapper(foreman_call, call_args=None):
 @click.option("--json_file", default=None, help="Path to json file with the list on certificater to delete")
 def clean_old_certificates(json_file, check_on_fs):
     """ This method that will clear all puppet cert for instances that do not still exist """
-
+    logging.info("########## Start Cleaning ###########")
     # connect to Foreman and ForemanProxy
     f = Foreman(foreman_url, (foreman_user, foreman_password), api_version=2)
     fp = ForemanProxy(foreman_proxy_url)
@@ -185,12 +185,6 @@ def clean_ds():
 @main.command()
 def clean_old_host():
     """ Method call by cron to clean instances """
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
-    sh = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    sh.setFormatter(formatter)
-    logger.addHandler(sh)
     logging.info("########## Start Cleaning ###########")
 
     # connect to Foreman and ForemanProxy
@@ -268,4 +262,10 @@ def clean_old_host():
 
 # Read option
 if __name__ == "__main__":
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    sh = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    sh.setFormatter(formatter)
+    logger.addHandler(sh)
     main()

--- a/files/install/requirements.txt
+++ b/files/install/requirements.txt
@@ -1,0 +1,5 @@
+click 
+python-foreman 
+requests 
+python-ldap 
+boto3


### PR DESCRIPTION
With the current system the cleaner try to remove all certificates return by the api without the active hosts in foreman. I add a filter to remove all certificate no valid. 

For with more 47000 certificates and just 300 host we see a huge difference